### PR TITLE
Chess board rework

### DIFF
--- a/chess_board_tests/board_tests.cpp
+++ b/chess_board_tests/board_tests.cpp
@@ -2,6 +2,9 @@
 #include "chess_board.h"
 #include "check_terminal/check.h"
 #include "check_terminal/checkmate.h"
+#include "utility.h"
+
+using namespace internal;
 
 class ChessBoardTest : public ::testing::Test {
 protected:
@@ -16,12 +19,15 @@ TEST_F(ChessBoardTest, InitialBoardEquality) {
 }
 
 TEST_F(ChessBoardTest, BoardInequalityDifferentCastling) {
-    ChessBoard board2 = board;
+
+    // turn off white queenside castling for another board
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::turnOffCastling(boardData, Color::WHITE, true);
+
     // Simulate castling right lost
-    ChessBoard board3(
-        board2.board(), board2.whiteKingCoord(), board2.blackKingCoord(),
-        false, true, true, true, std::nullopt, std::nullopt
-    );
+    ChessBoard board3(boardData);
+
     EXPECT_FALSE(board == board3);
 }
 
@@ -45,55 +51,62 @@ TEST_F(ChessBoardTest, KingIsCheckedNone) {
 
 TEST_F(ChessBoardTest, KingIsCheckedByPawn) {
     // Place black pawn in front of white king
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('d', 2).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('d', 2), ChessPiece::BLACK_PAWN);
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_EQ(attackers.size(), 1);
     EXPECT_TRUE(attackers.count(Coord2D('d', 2)));
 }
 
 TEST_F(ChessBoardTest, KingIsCheckedByKnight) {
-    std::string b = board.board();
-    b[Coord2D('f', 3).toFlatIdx()] = ChessPiece::BLACK_KNIGHT;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('f', 3), ChessPiece::BLACK_KNIGHT);
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_TRUE(attackers.count(Coord2D('f', 3)));
 }
 
 TEST_F(ChessBoardTest, KingIsCheckedByRook) {
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 3).toFlatIdx()] = ChessPiece::BLACK_ROOK;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 3), ChessPiece::BLACK_ROOK);
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_TRUE(attackers.count(Coord2D('e', 3)));
 }
 
 TEST_F(ChessBoardTest, KingIsCheckedByBishop) {
-    std::string b = board.board();
-    b[Coord2D('f', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('g', 3).toFlatIdx()] = ChessPiece::BLACK_BISHOP;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('f', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('g', 3), ChessPiece::BLACK_BISHOP);
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_TRUE(attackers.count(Coord2D('g', 3)));
 }
 
 TEST_F(ChessBoardTest, KingIsCheckedByQueen) {
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 4).toFlatIdx()] = ChessPiece::BLACK_QUEEN;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 4), ChessPiece::BLACK_QUEEN);
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_TRUE(attackers.count(Coord2D('e', 4)));
 }
 
 TEST_F(ChessBoardTest, KingIsCheckedByKing) {
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::BLACK_KING;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 2), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::BLACK_KING);
+    
+    ChessBoard custom(boardData);
     auto attackers = CheckTerminal::kingIsChecked(custom, Color::WHITE);
     EXPECT_TRUE(attackers.count(Coord2D('e', 2)));
 }
@@ -112,32 +125,38 @@ TEST_F(ChessBoardTest, IsCheckmateFalseOnInitial) {
 
 TEST_F(ChessBoardTest, IsCheckmateTrueSimple) {
     // Fool's mate
-    std::string b = board.board();
-    b[Coord2D('f', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('g', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 7).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('d', 8).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('h', 4).toFlatIdx()] = ChessPiece::BLACK_QUEEN;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('f', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('g', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 7), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('d', 8), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('h', 4), ChessPiece::BLACK_QUEEN);
+    ChessBoard custom(boardData);
     EXPECT_EQ(CheckTerminal::isCheckmate(custom, Color::WHITE), CheckTerminal::MateStatus::CHECKMATE) << custom.getWhitePOV();
 }
 
 TEST_F(ChessBoardTest, IsCheckMateCustom1) {
-    std::string b(64, static_cast<Piece_t>(ChessPiece::NONE));
-    b[Coord2D('b', 1).toFlatIdx()] = b[Coord2D('b', 2).toFlatIdx()] = b[Coord2D('d', 1).toFlatIdx()] = static_cast<Piece_t>(ChessPiece::WHITE_ROOK);
-    b[Coord2D('c', 1).toFlatIdx()] = static_cast<Piece_t>(ChessPiece::WHITE_KING);
-    b[Coord2D('c', 2).toFlatIdx()] = static_cast<Piece_t>(ChessPiece::WHITE_BISHOP);
-    b[Coord2D('e', 1).toFlatIdx()] = b[Coord2D('e', 3).toFlatIdx()] = static_cast<Piece_t>(ChessPiece::BLACK_QUEEN);
-    b[Coord2D('e', 8).toFlatIdx()] = static_cast<Piece_t>(ChessPiece::BLACK_KING);
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('b', 1), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('b', 2), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('d', 1), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('c', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('c', 2), ChessPiece::WHITE_BISHOP);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::BLACK_QUEEN);
+    utility::writeData(boardData, Coord2D('e', 3), ChessPiece::BLACK_QUEEN);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
 
-    ChessBoard customBoard(b, Coord2D('c', 1), Coord2D('e', 8), false, false, false, false, std::nullopt, std::nullopt);
+    ChessBoard customBoard(boardData);
     EXPECT_EQ(CheckTerminal::isCheckmate(customBoard, Color::WHITE), CheckTerminal::MateStatus::CHECKMATE) << customBoard.getWhitePOV();
 }
 
 TEST_F(ChessBoardTest, IsCheckmateFalseIfKingCanEscape) {
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 3).toFlatIdx()] = ChessPiece::BLACK_ROOK;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 3), ChessPiece::BLACK_ROOK);
+    
+    ChessBoard custom(boardData);
     EXPECT_EQ(CheckTerminal::isCheckmate(custom, Color::WHITE), CheckTerminal::MateStatus::CHECK) << custom.getWhitePOV();
 }

--- a/chess_board_tests/move_tests.cpp
+++ b/chess_board_tests/move_tests.cpp
@@ -242,6 +242,24 @@ TEST_F(MoveTest, CastlingBlockedFails) {
     EXPECT_FALSE(result.has_value());
 }
 
+TEST_F(MoveTest, CastlingTwiceFail) {
+    char boardData[34] = { 0 };
+    boardData[32] = (1 << 4) - 1; // both castling rights available
+    utility::writeData(boardData, Coord2D('f', 1), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('g', 1), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('h', 1), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('a', 1), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard custom(boardData);
+    Castling m1(Color::WHITE, false);
+    auto result1 = m1(custom);
+    ASSERT_TRUE(result1.has_value());
+    Castling m2(Color::WHITE, true);
+    auto result2 = m2(result1.value());
+    EXPECT_FALSE(result2.has_value());
+}
+
 TEST_F(MoveTest, EnPassantWhite) {
     // White pawn moves two squares, black pawn captures en passant
     char boardData[34] = { 0 };

--- a/chess_board_tests/move_tests.cpp
+++ b/chess_board_tests/move_tests.cpp
@@ -7,6 +7,8 @@
 #include "check_terminal/check.h"
 #include "check_terminal/checkmate.h"
 
+using namespace internal;
+
 class MoveTest : public ::testing::Test {
 protected:
     ChessBoard board = ChessBoard();
@@ -15,23 +17,23 @@ protected:
 };
 
 TEST_F(MoveTest, QueensMoveWhiteRookValid) {
-    std::string rawBoard = board.board();
-    rawBoard[Coord2D('a', 2).toFlatIdx()] = ChessPiece::NONE;
-    rawBoard[Coord2D('h', 2).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(rawBoard, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
-    
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('a', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('h', 2), ChessPiece::NONE);
+    ChessBoard custom(boardData);
 
     QueensMove move1(Color::WHITE, Direction::UP, 2, Coord2D('a', 1));
     auto result1 = move1(custom);
     EXPECT_TRUE(result1.has_value());
     EXPECT_EQ(result1->getPiece(Coord2D('a', 3)), ChessPiece::WHITE_ROOK);
-    EXPECT_FALSE(result1->whiteLeftCastling());
+    EXPECT_FALSE(result1->castling(Color::WHITE, true));
 
     QueensMove move2(Color::WHITE, Direction::UP, 6, Coord2D('h', 1));
     auto result2 = move2(result1.value());
     EXPECT_TRUE(result2.has_value());
     EXPECT_EQ(result2->getPiece(Coord2D('h', 7)), ChessPiece::WHITE_ROOK);
-    EXPECT_FALSE(result2->whiteRightCastling());
+    EXPECT_FALSE(result2->castling(Color::WHITE, false));
 
     QueensMove move3(Color::WHITE, Direction::RIGHT, 4, Coord2D('a', 3));
     auto result3 = move3(result2.value());
@@ -45,29 +47,31 @@ TEST_F(MoveTest, QueensMoveWhiteRookValid) {
 }
 
 TEST_F(MoveTest, QueensMoveBlackRookValid) {
-    std::string rawBoard = board.board();
-    rawBoard[Coord2D('a', 7).toFlatIdx()] = ChessPiece::NONE;
-    rawBoard[Coord2D('h', 7).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(rawBoard, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('a', 7), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('h', 7), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     
     QueensMove move(Color::BLACK, Direction::UP, 2, Coord2D('a', 8));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
     EXPECT_EQ(result->getPiece(Coord2D('a', 6)), ChessPiece::BLACK_ROOK);
-    EXPECT_FALSE(result->blackRightCastling());
+    EXPECT_FALSE(result->castling(Color::BLACK, false));
 }
 
 TEST_F(MoveTest, QueensMoveWhiteBishopValid) {
-    std::string b = board.board();
-    b[Coord2D('d', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('d', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     QueensMove move(Color::WHITE, Direction::UP_RIGHT, 1, Coord2D('c', 1));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
     EXPECT_EQ(result->getPiece(Coord2D('d', 2)), ChessPiece::WHITE_BISHOP);
 
-    ChessBoard custom2(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    ChessBoard custom2(boardData);
     QueensMove move2(Color::WHITE, Direction::UP_LEFT, 3, Coord2D('f', 1));
     auto result2 = move2(custom2);
     EXPECT_TRUE(result2.has_value());
@@ -75,9 +79,10 @@ TEST_F(MoveTest, QueensMoveWhiteBishopValid) {
 }
 
 TEST_F(MoveTest, QueensMoveWhiteQueenCapture) {
-    std::string b = board.board();
-    b[Coord2D('d', 2).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('d', 2), ChessPiece::BLACK_PAWN);
+    ChessBoard custom(boardData);
     QueensMove move(Color::WHITE, Direction::UP, 1, Coord2D('d', 1));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -96,9 +101,10 @@ TEST_F(MoveTest, QueensMoveWrongColor) {
 }
 
 TEST_F(MoveTest, QueensMovePawnPromotion) {
-    std::string b = board.board();
-    b[Coord2D('e', 7).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 7), ChessPiece::WHITE_PAWN);
+    ChessBoard custom(boardData);
     QueensMove move(Color::WHITE, Direction::UP_RIGHT, 1, Coord2D('e', 7));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -120,9 +126,10 @@ TEST_F(MoveTest, KnightsMoveBlackValid) {
 }
 
 TEST_F(MoveTest, KnightsMoveCapture) {
-    std::string b = board.board();
-    b[Coord2D('c', 3).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('c', 3), ChessPiece::BLACK_PAWN);
+    ChessBoard custom(boardData);
     KnightsMove move(Color::WHITE, Vec2D(1, 2), Coord2D('b', 1));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -144,10 +151,11 @@ TEST_F(MoveTest, KnightsMoveInvalidDirectionThrows) {
 }
 
 TEST_F(MoveTest, UnderpromotionWhiteRook) {
-    std::string b = board.board();
-    b[Coord2D('a', 7).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    b[Coord2D('a', 2).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('a', 7), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('a', 2), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Underpromotion move(Color::WHITE, Direction::UP_RIGHT, Coord2D('a', 7), ChessPiece::WHITE_ROOK);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -155,10 +163,11 @@ TEST_F(MoveTest, UnderpromotionWhiteRook) {
 }
 
 TEST_F(MoveTest, UnderpromotionBlackKnight) {
-    std::string b = board.board();
-    b[Coord2D('h', 2).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    b[Coord2D('h', 1).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('h', 2), ChessPiece::BLACK_PAWN);
+    utility::writeData(boardData, Coord2D('h', 1), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Underpromotion move(Color::BLACK, Direction::UP, Coord2D('h', 2), ChessPiece::BLACK_KNIGHT);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -170,17 +179,19 @@ TEST_F(MoveTest, UnderpromotionInvalidRowThrows) {
 }
 
 TEST_F(MoveTest, UnderpromotionInvalidPieceThrows) {
-    std::string b = board.board();
-    b[Coord2D('a', 7).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('a', 7), ChessPiece::WHITE_PAWN);
+    ChessBoard custom(boardData);
     EXPECT_THROW(Underpromotion(Color::WHITE, Direction::UP, Coord2D('a', 7), ChessPiece::BLACK_QUEEN), std::invalid_argument);
 }
 
 TEST_F(MoveTest, CastlingWhiteKingside) {
-    std::string b = board.board();
-    b[Coord2D('f', 1).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('g', 1).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('f', 1), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('g', 1), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Castling move(Color::WHITE, false);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -188,11 +199,12 @@ TEST_F(MoveTest, CastlingWhiteKingside) {
 }
 
 TEST_F(MoveTest, CastlingWhiteQueenside) {
-    std::string b = board.board();
-    b[Coord2D('b', 1).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('c', 1).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('d', 1).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('b', 1), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('c', 1), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('d', 1), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Castling move(Color::WHITE, true);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -200,10 +212,11 @@ TEST_F(MoveTest, CastlingWhiteQueenside) {
 }
 
 TEST_F(MoveTest, CastlingBlackKingside) {
-    std::string b = board.board();
-    b[Coord2D('f', 8).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('g', 8).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('f', 8), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('g', 8), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Castling move(Color::BLACK, true);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -211,11 +224,12 @@ TEST_F(MoveTest, CastlingBlackKingside) {
 }
 
 TEST_F(MoveTest, CastlingBlackQueenside) {
-    std::string b = board.board();
-    b[Coord2D('b', 8).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('c', 8).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('d', 8).toFlatIdx()] = ChessPiece::NONE;
-    ChessBoard custom(b, Coord2D('e', 1), Coord2D('e', 8), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('b', 8), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('c', 8), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('d', 8), ChessPiece::NONE);
+    ChessBoard custom(boardData);
     Castling move(Color::BLACK, false);
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -230,11 +244,13 @@ TEST_F(MoveTest, CastlingBlockedFails) {
 
 TEST_F(MoveTest, EnPassantWhite) {
     // White pawn moves two squares, black pawn captures en passant
-    std::string b = board.board();
-    b[Coord2D('e', 2).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('e', 4).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    b[Coord2D('d', 4).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, Coord2D('e', 3));
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 2), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('e', 4), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('d', 4), ChessPiece::BLACK_PAWN);
+    utility::setEnPassant(boardData, Color::BLACK, Coord2D('e', 3));
+    ChessBoard custom(boardData);
     QueensMove move(Color::BLACK, Direction::UP_LEFT, 1, Coord2D('d', 4));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -244,11 +260,13 @@ TEST_F(MoveTest, EnPassantWhite) {
 
 TEST_F(MoveTest, EnPassantBlack) {
     // Black pawn moves two squares, white pawn captures en passant
-    std::string b = board.board();
-    b[Coord2D('d', 7).toFlatIdx()] = ChessPiece::NONE;
-    b[Coord2D('d', 5).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    b[Coord2D('e', 5).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, Coord2D('d', 6), std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('d', 7), ChessPiece::NONE);
+    utility::writeData(boardData, Coord2D('d', 5), ChessPiece::BLACK_PAWN);
+    utility::writeData(boardData, Coord2D('e', 5), ChessPiece::WHITE_PAWN);
+    utility::setEnPassant(boardData, Color::WHITE, Coord2D('d', 6));
+    ChessBoard custom(boardData);
     QueensMove move(Color::WHITE, Direction::UP_LEFT, 1, Coord2D('e', 5));
     auto result = move(custom);
     EXPECT_TRUE(result.has_value());
@@ -257,10 +275,11 @@ TEST_F(MoveTest, EnPassantBlack) {
 }
 
 TEST_F(MoveTest, EnPassantNotAvailable) {
-    std::string b = board.board();
-    b[Coord2D('e', 4).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    b[Coord2D('d', 4).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard custom(b, board.whiteKingCoord(), board.blackKingCoord(), true, true, true, true, std::nullopt, std::nullopt);
+    char boardData[34] = { 0 };
+    std::copy(board.boardData(), board.boardData() + 34, boardData);
+    utility::writeData(boardData, Coord2D('e', 4), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('d', 4), ChessPiece::BLACK_PAWN);
+    ChessBoard custom(boardData);
     QueensMove move(Color::BLACK, Direction::UP_RIGHT, 1, Coord2D('d', 4));
     auto result = move(custom);
     EXPECT_FALSE(result.has_value());
@@ -305,36 +324,13 @@ TEST(GetAllMoves, InitialPositionBlack) {
     }
 }
 
-TEST(GetAllMoves, EmptyBoard) {
-    ChessBoard board(
-        std::string(64, ChessPiece::NONE),
-        Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
-    auto moves = getAllMoves(board, Color::WHITE, true);
-    EXPECT_EQ(moves.size(), 0);
-
-    // ensure all moves lead to a valid state
-    for (const auto& move : moves) {
-        auto newState = (*move)(board);
-        ASSERT_TRUE(newState.has_value());
-        EXPECT_TRUE(CheckTerminal::kingIsChecked(newState.value(), Color::WHITE).empty());
-    }
-}
-
 TEST(GetAllMoves, OnlyKing) {
-    ChessBoard board(
-        std::string(64, ChessPiece::NONE),
-        Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
-    // Place white king at E1
-    std::string raw = board.board();
-    raw[Coord2D('e', 1).toFlatIdx()] = ChessPiece::WHITE_KING;
-    ChessBoard kingBoard(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+
+    ChessBoard kingBoard(boardData);
     auto moves = getAllMoves(kingBoard, Color::WHITE, true);
     // King at E1 has 5 possible moves (D1, D2, E2, F1, F2) but only those on board
     EXPECT_EQ(moves.size(), 5);
@@ -343,106 +339,97 @@ TEST(GetAllMoves, OnlyKing) {
     // ensure all moves lead to a valid state
     for (const auto& move : moves) {
         auto newState = (*move)(kingBoard);
-        ASSERT_TRUE(newState.has_value()) << board.getWhitePOV();
+        ASSERT_TRUE(newState.has_value());
         EXPECT_TRUE(CheckTerminal::kingIsChecked(newState.value(), Color::WHITE).empty());
     }
 }
 
 TEST(GetAllMoves, PawnPromotionMoves) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('a', 7).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('a', 7), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Pawn at A7 can move to A8 (promotion), or capture at B8 if enemy present
-    EXPECT_GE(moves.size(), 4);
+    EXPECT_GE(moves.size(), 9);
 
-    raw[Coord2D('b', 8).toFlatIdx()] = ChessPiece::BLACK_KNIGHT;
-    ChessBoard boardWithCapture(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    utility::writeData(boardData, Coord2D('b', 8), ChessPiece::BLACK_KNIGHT);
+    ChessBoard boardWithCapture(boardData);
     auto captureMoves = getAllMoves(boardWithCapture, Color::WHITE, false);
     // Now pawn can capture at B8
-    EXPECT_GE(captureMoves.size(), 8);
+    EXPECT_GE(captureMoves.size(), 13);
 }
 
 TEST(GetAllMoves, BlockedPawn) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('a', 2).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    raw[Coord2D('a', 3).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('a', 2), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('a', 3), ChessPiece::BLACK_PAWN);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Pawn is blocked, should have no moves
-    EXPECT_EQ(moves.size(), 0) << board.getWhitePOV();
+    EXPECT_EQ(moves.size(), 5) << board.getWhitePOV();
 }
 
 TEST(GetAllMoves, PawnEnPassant) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('e', 4).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    raw[Coord2D('d', 4).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, Coord2D('e', 3)
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('e', 4), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('d', 4), ChessPiece::BLACK_PAWN);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    utility::setEnPassant(boardData, Color::BLACK, Coord2D('e', 3));
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::BLACK, false);
     // Pawn at E4 can capture en passant at D3
-    EXPECT_EQ(moves.size(), 2);
-    EXPECT_EQ(CountMoveType<QueensMove>(moves), 2);
+    EXPECT_EQ(moves.size(), 7);
+    EXPECT_EQ(CountMoveType<QueensMove>(moves), 7);
 }
 
 TEST(GetAllMoves, KnightJumpOverPieces) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('b', 1).toFlatIdx()] = ChessPiece::WHITE_KNIGHT;
-    raw[Coord2D('b', 2).toFlatIdx()] = ChessPiece::WHITE_PAWN;
-    raw[Coord2D('c', 3).toFlatIdx()] = ChessPiece::BLACK_PAWN;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('b', 1), ChessPiece::WHITE_KNIGHT);
+    utility::writeData(boardData, Coord2D('b', 2), ChessPiece::WHITE_PAWN);
+    utility::writeData(boardData, Coord2D('c', 3), ChessPiece::BLACK_PAWN);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Knight at B1 should have 2 moves: A3, C3 (C3 is a capture)
-    EXPECT_EQ(moves.size(), 6) << board.getWhitePOV();
+    EXPECT_EQ(moves.size(), 11) << board.getWhitePOV();
     EXPECT_EQ(CountMoveType<KnightsMove>(moves), 3);
 }
 
 TEST(GetAllMoves, RookMoves) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('d', 4).toFlatIdx()] = ChessPiece::WHITE_ROOK;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('d', 4), ChessPiece::WHITE_ROOK);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Rook at D4 should have 14 moves (7 up, 7 down, 3 left, 4 right)
-    EXPECT_EQ(moves.size(), 14);
+    EXPECT_EQ(moves.size(), 19);
 }
 
 TEST(GetAllMoves, BishopMoves) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('c', 1).toFlatIdx()] = ChessPiece::WHITE_BISHOP;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('c', 1), ChessPiece::WHITE_BISHOP);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Bishop at C1 should have 7 moves (diagonals)
-    EXPECT_EQ(moves.size(), 7);
+    EXPECT_EQ(moves.size(), 12);
 }
 
 TEST(GetAllMoves, QueenMoves) {
-    std::string raw(64, ChessPiece::NONE);
-    raw[Coord2D('d', 4).toFlatIdx()] = ChessPiece::WHITE_QUEEN;
-    ChessBoard board(
-        raw, Coord2D('e', 1), Coord2D('e', 8),
-        false, false, false, false, std::nullopt, std::nullopt
-    );
+    char boardData[34] = { 0 };
+    utility::writeData(boardData, Coord2D('d', 4), ChessPiece::WHITE_QUEEN);
+    utility::writeData(boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    utility::writeData(boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
+    ChessBoard board(boardData);
     auto moves = getAllMoves(board, Color::WHITE, false);
     // Queen at D4 should have 27 moves (rook + bishop moves)
-    EXPECT_EQ(moves.size(), 27);
+    EXPECT_EQ(moves.size(), 32);
 }

--- a/chess_library_src/CMakeLists.txt
+++ b/chess_library_src/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(
         ${CMAKE_CURRENT_LIST_DIR}/chess_board.cpp
         ${CMAKE_CURRENT_LIST_DIR}/coord2D.h
         ${CMAKE_CURRENT_LIST_DIR}/coord2D.cpp 
+        ${CMAKE_CURRENT_LIST_DIR}/utility.h
         ${CMAKE_CURRENT_LIST_DIR}/square_iterator/reachability.h
         ${CMAKE_CURRENT_LIST_DIR}/square_iterator/r_bishop.h
         ${CMAKE_CURRENT_LIST_DIR}/square_iterator/r_bishop.cpp 

--- a/chess_library_src/check_terminal/check.cpp
+++ b/chess_library_src/check_terminal/check.cpp
@@ -2,16 +2,32 @@
 #include "../square_iterator/next_square_iterator.h"
 
 #include <stdexcept>
+#include <iostream>
 
 namespace CheckTerminal
 {
     std::unordered_set<Coord2D> kingIsChecked(const ChessBoard& board, Color kingsColor) {
         
+        if (kingsColor == Color::NONE) {
+            throw std::invalid_argument("An invalid player color passed into function");
+        }
+
         // store all coordinates of pieces capturing the king 
         std::unordered_set<Coord2D> res;
 
+        // find king's position
+        Coord2D kingCoord;
+        for (char col = 'a'; col <= 'h'; ++col) {
+            for (int8_t row = 1; row <= 8; ++row) {
+                Coord2D coord(col, row);
+                ChessPiece piece = board.getPiece(coord); 
+                if (piece.isKing() && piece.color() == kingsColor) {
+                    kingCoord = coord; break;
+                }
+            }
+        }
+
         // find the king's position
-        Coord2D kingCoord = kingsColor == Color::WHITE ? board.whiteKingCoord() : board.blackKingCoord();
         ChessPiece kingPiece = board.getPiece(kingCoord);
 
         // scan the board for all pieces of opposite color 

--- a/chess_library_src/chess_board.cpp
+++ b/chess_library_src/chess_board.cpp
@@ -1,4 +1,6 @@
 #include "chess_board.h"
+#include "utility.h"
+
 #include <stdexcept>
 #include <utility>
 
@@ -6,103 +8,50 @@
 
 // namespace py = pybind11;
 
-/**
- * @brief A private static method of `ChessBoard` class. Returns a string representation of a chess board
- * when starting the game.
- * 
- * @return `std::string` raw string as initial board state  
- */
-std::string ChessBoard::initRawBoard() {
-    std::string rawBoard(
-        Coord2D::BOARD_SIZE * Coord2D::BOARD_SIZE, 
-        static_cast<char>(ChessPiece::NONE)
-    );
+void ChessBoard::_initData() {
     
-    // assign pawns
-    for (int p =  8; p <= 15; ++p) rawBoard[p] = static_cast<char>(ChessPiece::WHITE_PAWN);
-    for (int p = 48; p <= 55; ++p) rawBoard[p] = static_cast<char>(ChessPiece::BLACK_PAWN);
+    // initialize pawns 
+    for (char col = 'a'; col <= 'h'; ++col) {
+        internal::utility::writeData(_boardData, Coord2D(col, 2), ChessPiece::WHITE_PAWN);
+        internal::utility::writeData(_boardData, Coord2D(col, 7), ChessPiece::BLACK_PAWN);
+    }
 
-    // assign everything else 
-    rawBoard[0] = rawBoard[7] = static_cast<char>(ChessPiece::WHITE_ROOK);
-    rawBoard[1] = rawBoard[6] = static_cast<char>(ChessPiece::WHITE_KNIGHT);
-    rawBoard[2] = rawBoard[5] = static_cast<char>(ChessPiece::WHITE_BISHOP);
-    rawBoard[4] = static_cast<char>(ChessPiece::WHITE_KING);
-    rawBoard[3] = static_cast<char>(ChessPiece::WHITE_QUEEN);
+    // initialize rooks
+    internal::utility::writeData(_boardData, Coord2D('a', 1), ChessPiece::WHITE_ROOK);
+    internal::utility::writeData(_boardData, Coord2D('h', 1), ChessPiece::WHITE_ROOK);
+    internal::utility::writeData(_boardData, Coord2D('a', 8), ChessPiece::BLACK_ROOK);
+    internal::utility::writeData(_boardData, Coord2D('h', 8), ChessPiece::BLACK_ROOK);
 
-    rawBoard[56] = rawBoard[63] = static_cast<char>(ChessPiece::BLACK_ROOK);
-    rawBoard[57] = rawBoard[62] = static_cast<char>(ChessPiece::BLACK_KNIGHT);
-    rawBoard[58] = rawBoard[61] = static_cast<char>(ChessPiece::BLACK_BISHOP);
-    rawBoard[60] = static_cast<char>(ChessPiece::BLACK_KING);
-    rawBoard[59] = static_cast<char>(ChessPiece::BLACK_QUEEN);
+    // initialize knights
+    internal::utility::writeData(_boardData, Coord2D('b', 1), ChessPiece::WHITE_KNIGHT);
+    internal::utility::writeData(_boardData, Coord2D('g', 1), ChessPiece::WHITE_KNIGHT);
+    internal::utility::writeData(_boardData, Coord2D('b', 8), ChessPiece::BLACK_KNIGHT);
+    internal::utility::writeData(_boardData, Coord2D('g', 8), ChessPiece::BLACK_KNIGHT);
 
-    return rawBoard;
-}
+    // initialize bishops
+    internal::utility::writeData(_boardData, Coord2D('c', 1), ChessPiece::WHITE_BISHOP);
+    internal::utility::writeData(_boardData, Coord2D('f', 1), ChessPiece::WHITE_BISHOP);
+    internal::utility::writeData(_boardData, Coord2D('c', 8), ChessPiece::BLACK_BISHOP);
+    internal::utility::writeData(_boardData, Coord2D('f', 8), ChessPiece::BLACK_BISHOP);
 
-ChessBoard::ChessBoard() : 
-    _board(ChessBoard::initRawBoard()), 
-    _whiteLeftCastling(true),
-    _whiteRightCastling(true),
-    _blackLeftCastling(true),
-    _blackRightCastling(true),
-    _whiteEnpassant(std::nullopt),
-    _blackEnpassant(std::nullopt),
-    _whiteKingCoord('e', 1),
-    _blackKingCoord('e', 8) {
+    // initialize kings/queens
+    internal::utility::writeData(_boardData, Coord2D('d', 1), ChessPiece::WHITE_QUEEN);
+    internal::utility::writeData(_boardData, Coord2D('e', 1), ChessPiece::WHITE_KING);
+    internal::utility::writeData(_boardData, Coord2D('d', 8), ChessPiece::BLACK_QUEEN);
+    internal::utility::writeData(_boardData, Coord2D('e', 8), ChessPiece::BLACK_KING);
 
-}
-
-ChessBoard::ChessBoard(
-        std::string board,
-        Coord2D whiteKingCoord,
-        Coord2D blackKingCoord,
-        const bool whiteLeftCastling,
-        const bool whiteRightCastling,
-        const bool blackLeftCastling,
-        const bool blackRightCastling,
-        const std::optional<Coord2D>& whiteEnpassant,
-        const std::optional<Coord2D>& blackEnpassant
-    ) : 
-    _board(std::move(board)),
-    _whiteLeftCastling(whiteLeftCastling),
-    _whiteRightCastling(whiteRightCastling),
-    _blackLeftCastling(blackLeftCastling),
-    _blackRightCastling(blackRightCastling),
-    _whiteEnpassant(whiteEnpassant),
-    _blackEnpassant(blackEnpassant),
-    _whiteKingCoord(whiteKingCoord),
-    _blackKingCoord(blackKingCoord) {
+    // initialize castling rights/en passant square
+    _boardData[32] = (1 << 4) - 1;
+    _boardData[33] = 0;
 
 }
 
-ChessPiece ChessBoard::getPiece(Coord2D coord) const {
-    
-    if (!(coord.row() >= 1 && coord.row() <= 8) && (coord.col() >= 'a' && coord.col() <= 'h')) {
-        throw std::out_of_range("Position on the board must be <a-h><1-8>");
-    }
-
-    int idx = coord.toFlatIdx(); 
-    char p = _board[idx];
-    return ChessPiece(p);
+ChessBoard::ChessBoard() {
+    _initData();
 }
 
-bool ChessBoard::operator==(const ChessBoard& other) const {
-    if (this->_board != other._board) {
-        return false;
-    }
-
-    if (this->_whiteLeftCastling != other._whiteLeftCastling || this->_blackLeftCastling != other._blackLeftCastling) {
-        return false;
-    }
-
-    if (this->_whiteRightCastling != other._whiteRightCastling || this->_blackRightCastling != other._blackRightCastling) {
-        return false;
-    }
-
-    if (this->_whiteEnpassant != other._whiteEnpassant || this->_blackEnpassant != other._blackEnpassant) {
-        return false;
-    }
-
-    return true;
+ChessBoard::ChessBoard(const char* boardData) {
+    std::copy(boardData, boardData + 34, _boardData);
 }
 
 std::string ChessBoard::getWhitePOV() const {

--- a/chess_library_src/chess_board.h
+++ b/chess_library_src/chess_board.h
@@ -43,7 +43,7 @@ public:
         return internal::utility::getData(_boardData, coord);
     }
 
-    bool operator==(const ChessBoard& other) const {
+    inline bool operator==(const ChessBoard& other) const {
         return memcmp(_boardData, other.boardData(), 34) == 0;
     }
 

--- a/chess_library_src/chess_board.h
+++ b/chess_library_src/chess_board.h
@@ -2,13 +2,17 @@
 
 #include "coord2D.h"
 #include "chess_piece.h"
+#include "utility.h"
 
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <string>
 #include <optional>
 #include <unordered_set>
 #include <vector>
+
+#include <iostream>
 
 /**
  * @brief A representation of the current chess board state. 
@@ -21,82 +25,37 @@ public:
     
     ChessBoard();
 
-    ChessBoard(
-        std::string board,
-        Coord2D whiteKingCoord,
-        Coord2D blackKingCoord,
-        bool whiteLeftCastling,
-        bool whiteRightCastling,
-        bool blackLeftCastling,
-        bool blackRightCastling,
-        const std::optional<Coord2D>& whiteEnpassant, 
-        const std::optional<Coord2D>& blackEnpassant
-    );
+    ChessBoard(const char* boardData);
 
-    [[nodiscard]] inline const std::string& board() const {
-        return _board;
+    [[nodiscard]] inline const char* boardData() const {
+        return _boardData;
     }
     
-    [[nodiscard]] inline bool whiteLeftCastling() const {
-        return _whiteLeftCastling;
+    [[nodiscard]] inline bool castling(Color color, bool isQueenside) const {
+        return internal::utility::getCastling(_boardData, color, isQueenside);
+    } 
+
+    [[nodiscard]] inline std::optional<Coord2D> enpassant(Color color) const {
+        return internal::utility::getEnPassant(_boardData, color);
     }
 
-     [[nodiscard]] inline bool blackLeftCastling() const {
-        return _blackLeftCastling;
+    [[nodiscard]] inline ChessPiece getPiece(Coord2D coord) const {
+        return internal::utility::getData(_boardData, coord);
     }
 
-     [[nodiscard]] inline bool whiteRightCastling() const {
-        return _whiteRightCastling;
+    bool operator==(const ChessBoard& other) const {
+        return memcmp(_boardData, other.boardData(), 34) == 0;
     }
 
-     [[nodiscard]] inline bool blackRightCastling() const {
-        return _blackRightCastling;
-    }
-
-     [[nodiscard]] inline const std::optional<Coord2D>& whiteEnpassant() const {
-        return _whiteEnpassant;
-    }
-
-     [[nodiscard]] inline const std::optional<Coord2D>& blackEnpassant() const {
-        return _blackEnpassant;
-    }
-
-    [[nodiscard]] inline const Coord2D& whiteKingCoord() const {
-        return _whiteKingCoord;
-    }
-
-     [[nodiscard]] inline const Coord2D& blackKingCoord() const {
-        return _blackKingCoord;
-    }
-
-    [[nodiscard]] ChessPiece getPiece(Coord2D coord) const;
-    bool operator==(const ChessBoard& other) const;
     [[nodiscard]] std::string getWhitePOV() const;
     [[nodiscard]] std::string getBlackPOV() const;
     
 private:
     
-    static std::string initRawBoard();
+    void _initData();
 
     // raw board representation
-    std::string _board;
-
-    // specify the king's coordinates
-    Coord2D _whiteKingCoord;
-    Coord2D _blackKingCoord;
-
-    // specify whether the white player can perform castling
-    bool _whiteLeftCastling;
-    bool _whiteRightCastling;
-
-    // specify whether the black player can perform castling
-    bool _blackLeftCastling;
-    bool _blackRightCastling;
-
-    // specify which pawn just performed a 2-square advance; said
-    // pawn is susceptible to en passant 
-    std::optional<Coord2D> _whiteEnpassant;
-    std::optional<Coord2D> _blackEnpassant;
+    char _boardData[34] = { 0 };
 
 };
 
@@ -105,15 +64,7 @@ struct std::hash<ChessBoard> {
 
     std::size_t operator()(const ChessBoard& board) const noexcept {
         std::hash<std::string> rawBoardHasher;
-        std::size_t hRawBoard = rawBoardHasher(board.board());
-
-        hRawBoard <<=     (board.whiteLeftCastling());
-        hRawBoard <<= 2 * (board.blackLeftCastling());
-        hRawBoard <<= 3 * (board.whiteEnpassant().has_value());
-        hRawBoard <<= 4 * (board.blackEnpassant().has_value());
-        hRawBoard <<= 5 * (board.whiteRightCastling());
-        hRawBoard <<= 6 * (board.blackRightCastling());
-
+        std::size_t hRawBoard = rawBoardHasher(std::string(board.boardData(), board.boardData() + 34));
         return hRawBoard;
     }
 

--- a/chess_library_src/chess_piece.h
+++ b/chess_library_src/chess_piece.h
@@ -1,6 +1,6 @@
 #pragma once
 
-typedef char Piece_t;
+typedef uint8_t Piece_t;
 
 #include <stdexcept>
 
@@ -30,8 +30,8 @@ private:
 
 class ChessPiece {
 public:
-    enum Piece : char {
-        NONE = 1,
+    enum Piece : Piece_t {
+        NONE = 0,
         WHITE_PAWN, 
         WHITE_ROOK, 
         WHITE_KNIGHT, 

--- a/chess_library_src/moves/castling.cpp
+++ b/chess_library_src/moves/castling.cpp
@@ -1,5 +1,8 @@
 #include "castling.h"
 #include "../check_terminal/check.h"
+#include "../utility.h"
+
+#include <cstring>
 
 /**
  * @brief Construct for the Castling's move
@@ -19,12 +22,7 @@ Castling::Castling(Color color, bool isLeft) noexcept :
  */
 std::optional<ChessBoard> Castling::operator()(const ChessBoard& state) const {
     // check if castling is allowed in the first place 
-    if (_color == Color::WHITE) {
-        if ((_isLeft && !state.whiteLeftCastling()) || (!_isLeft && !state.whiteRightCastling())) {
-            return std::nullopt;
-        }
-    }
-    if ((_isLeft && !state.blackLeftCastling()) || (!_isLeft && !state.blackRightCastling())) {
+    if (!state.castling(_color, _isLeft)) {
         return std::nullopt;
     }
 
@@ -44,64 +42,33 @@ std::optional<ChessBoard> Castling::operator()(const ChessBoard& state) const {
     Coord2D rookPos = Coord2D(rookCol, row);
     Coord2D kingPos = Coord2D('e', row);
 
-    // get raw board 
-    std::string rawBoard = state.board();
-
     // check if there are any pieces between the king and the rook
     for (Coord2D iter = rookPos + mv; iter != kingPos; iter = iter + mv) {
         // there exists a piece in between -> castling is impossible
-        if (rawBoard[iter.toFlatIdx()] != ChessPiece::NONE) {
+        if (!state.getPiece(iter).isNone()) {
             return std::nullopt;
         }
     }
 
-    // update en passant square
-    std::optional<Coord2D> whiteEnpassant = std::nullopt, blackEnpassant = std::nullopt;
+    // get raw board 
+    char boardData[34] = { 0 };
+    std::copy(state.boardData(), state.boardData() + 34, boardData);
+    
+    // disable castling for the move 
+    internal::utility::turnOffCastling(boardData, _color, _isLeft);
 
-    // update castling rights
-    bool newWhiteLeftCastling = state.whiteLeftCastling(), 
-    newWhiteRightCastling = state.whiteRightCastling(), 
-    newBlackLeftCastling  = state.blackLeftCastling(), 
-    newBlackRightCastling = state.blackRightCastling();
-    
-    if (_color == Color::WHITE) {
-        if (_isLeft) newWhiteLeftCastling = false;
-        else newWhiteRightCastling = false;
-    }
-    else {
-        if (_isLeft) newBlackLeftCastling = false;
-        else newBlackRightCastling = false;
-    }
-    
     // perform transformation
-    Piece_t king = rawBoard[kingPos.toFlatIdx()], rook = rawBoard[rookPos.toFlatIdx()];
-    
     Vec2D kingMv = mv * -2;
     Coord2D newKingPos = kingPos + kingMv;
 
-    rawBoard[kingPos.toFlatIdx()] = ChessPiece::NONE;
-    rawBoard[newKingPos.toFlatIdx()] = king;
+    internal::utility::writeData(boardData, kingPos, ChessPiece::NONE);
+    internal::utility::writeData(boardData, newKingPos, state.getPiece(kingPos));
 
-    rawBoard[rookPos.toFlatIdx()] = ChessPiece::NONE;
-    rawBoard[(newKingPos + mv).toFlatIdx()] = rook;
+    internal::utility::writeData(boardData, rookPos, ChessPiece::NONE);
+    internal::utility::writeData(boardData, newKingPos + mv, state.getPiece(rookPos));
 
-    Coord2D newWhiteKingCoord = state.whiteKingCoord(), newBlackKingCoord = state.blackKingCoord();
+    // disable en passant 
+    internal::utility::turnOffEnpassant(boardData);
 
-    if (_color == Color::WHITE) {
-        newWhiteKingCoord = newKingPos;
-    } else {
-        newBlackKingCoord = newKingPos;
-    }
-
-    return ChessBoard(
-        rawBoard, 
-        newWhiteKingCoord,
-        newBlackKingCoord,
-        newWhiteLeftCastling, 
-        newWhiteRightCastling, 
-        newBlackLeftCastling, 
-        newBlackRightCastling, 
-        whiteEnpassant, 
-        blackEnpassant
-    );
+    return ChessBoard(boardData);
 }

--- a/chess_library_src/moves/castling.cpp
+++ b/chess_library_src/moves/castling.cpp
@@ -3,6 +3,7 @@
 #include "../utility.h"
 
 #include <cstring>
+#include <optional>
 
 /**
  * @brief Construct for the Castling's move
@@ -55,7 +56,8 @@ std::optional<ChessBoard> Castling::operator()(const ChessBoard& state) const {
     std::copy(state.boardData(), state.boardData() + 34, boardData);
     
     // disable castling for the move 
-    internal::utility::turnOffCastling(boardData, _color, _isLeft);
+    internal::utility::turnOffCastling(boardData, _color, true);
+    internal::utility::turnOffCastling(boardData, _color, false);
 
     // perform transformation
     Vec2D kingMv = mv * -2;

--- a/chess_library_src/moves/chess_move.cpp
+++ b/chess_library_src/moves/chess_move.cpp
@@ -1,4 +1,5 @@
 #include "chess_move.h"
+#include "../utility.h"
 
 /**
  * This method is used to update the turn's castling rights, given some move might capture a rook in its initial position.
@@ -6,37 +7,31 @@
  * @param state The original state to be transitioned
  * @param turn Whose turn it is to play
  * @param newPoint The new position of the piece to be moved
- * @param newWhiteLeftCastling Reference to white player's left castling's right
- * @param newWhiteRightCastling Reference to white player's right castling's right
- * @param newBlackLeftCastling Reference to black player's left castling's right
- * @param newBlackRightCastling Reference to black player's right castling's right
+ * @param boardData The board data of the next state
  */
 void ChessMove::updateCastling(
     const ChessBoard& state, 
     Color turn,
     Coord2D newPoint,
-    bool& newWhiteLeftCastling, 
-    bool& newWhiteRightCastling, 
-    bool& newBlackLeftCastling, 
-    bool& newBlackRightCastling) {
+    char* boardData) {
 
     if (turn == Color::WHITE) {
         // if the rook is at the original place and castling right still exists
         // capture it and castling right is forfeit
-        if (state.blackLeftCastling() && newPoint == Coord2D('h', 8)) {
-            newBlackLeftCastling = false; 
+        if (state.castling(~turn, true) && newPoint == Coord2D('h', 8)) {
+            internal::utility::turnOffCastling(boardData, ~turn, true);
         } 
-        else if (state.blackRightCastling() && newPoint == Coord2D('a', 8)) {
-            newBlackRightCastling = false;
+        else if (state.castling(~turn, false) && newPoint == Coord2D('a', 8)) {
+            internal::utility::turnOffCastling(boardData, ~turn, false);
         }
     }   
-    else if (turn == Color::BLACK) {
+    else {
         // same logic applies
-        if (state.whiteLeftCastling() && newPoint == Coord2D('a', 1)) {
-            newWhiteLeftCastling = false; 
+        if (state.castling(~turn, true) && newPoint == Coord2D('a', 1)) {
+            internal::utility::turnOffCastling(boardData, ~turn, true);
         } 
-        else if (state.whiteRightCastling() && newPoint == Coord2D('h', 1)) {
-            newWhiteRightCastling = false;
+        else if (state.castling(~turn, false) && newPoint == Coord2D('h', 1)) {
+            internal::utility::turnOffCastling(boardData, ~turn, false);
         }
     }
 }

--- a/chess_library_src/moves/chess_move.h
+++ b/chess_library_src/moves/chess_move.h
@@ -15,10 +15,7 @@ protected:
         const ChessBoard& state, 
         Color turn,
         Coord2D newPoint, 
-        bool& newWhiteLeftCastling, 
-        bool& newWhiteRightCastling, 
-        bool& newBlackLeftCastling, 
-        bool& newBlackRightCastling);
+        char* boardData);
             
     Color _color;
         

--- a/chess_library_src/moves/get_all_moves.cpp
+++ b/chess_library_src/moves/get_all_moves.cpp
@@ -53,10 +53,20 @@ std::vector<std::shared_ptr<ChessMove>> getAllMoves(
         
         bool isWhiteTurn = turn == Color::WHITE;
         
-        bool leftCastling = (isWhiteTurn && board.whiteLeftCastling()) || (!isWhiteTurn && board.blackLeftCastling());
-        bool rightCastling = (isWhiteTurn && board.whiteRightCastling()) || (!isWhiteTurn && board.blackRightCastling());
+        bool leftCastling = board.castling(turn, true);
+        bool rightCastling = board.castling(turn, false);
         
-        Coord2D kingCoord = isWhiteTurn ? board.whiteKingCoord() : board.blackKingCoord();
+        Coord2D kingCoord;
+        for (char col = 'a'; col <= 'h'; ++col) {
+            for (int8_t row = 1; row <= 8; ++row) {
+                Coord2D coord(col, row);
+                ChessPiece piece = board.getPiece(coord); 
+                if (piece.isKing() && piece.color() == turn) {
+                    kingCoord = coord; break;
+                }
+            }
+        }
+
         ChessPiece rook = isWhiteTurn ? ChessPiece::WHITE_ROOK : ChessPiece::BLACK_ROOK; 
 
         if (leftCastling) {

--- a/chess_library_src/moves/knights_move.cpp
+++ b/chess_library_src/moves/knights_move.cpp
@@ -1,4 +1,5 @@
 #include "knights_move.h"
+#include "../utility.h"
 
 #include <stdexcept>
 
@@ -60,51 +61,26 @@ std::optional<ChessBoard> KnightsMove::operator()(const ChessBoard& state) const
     }
             
     // get new point
-    Coord2D newPoint = _origin + _direction;
-
+    Coord2D dest = _origin + _direction;
 
     // check if the position is valid (i.e. knights cannot capture pieces of the same color)
-    if (piece.color() == state.getPiece(newPoint).color()) {
+    if (piece.color() == state.getPiece(dest).color()) {
 
         return std::nullopt;
     }
-        
-    // update enpassant squares (since the knight has moved, the opponent's enpassant square is invalidated)
-    // since in this turn, a knight moves, there will not be any enpassant square for the home player
-    std::optional<Coord2D> newWhiteEnpassant = std::nullopt;
-    std::optional<Coord2D> newBlackEnpassant = std::nullopt; 
-    
-    // update castling rights
-    bool newWhiteLeftCastling = state.whiteLeftCastling(),
-        newWhiteRightCastling = state.whiteRightCastling(), 
-        newBlackLeftCastling  = state.blackLeftCastling(), 
-        newBlackRightCastling = state.blackRightCastling();
-    
-    // update castling
-    updateCastling(state, _color, newPoint, newWhiteLeftCastling, newWhiteRightCastling, newBlackLeftCastling, newBlackRightCastling);
 
     // get the raw board
-    std::string rawBoard = state.board();
-
-    const uint8_t originIdx = _origin.toFlatIdx();
-    // move
-    const uint8_t destIdx = newPoint.toFlatIdx();
-
+    char boardData[34] = { 0 };
+    std::copy(state.boardData(), state.boardData() + 34, boardData);
 
     // transform the raw board 
-    rawBoard[originIdx] = static_cast<char>(ChessPiece::NONE);
-    rawBoard[destIdx] = piece;
+    internal::utility::writeData(boardData, _origin, ChessPiece::NONE);
+    internal::utility::writeData(boardData, dest, piece);
+    
+    // update castling + en passant
+    updateCastling(state, _color, dest, boardData);
+    internal::utility::turnOffEnpassant(boardData);
 
     // return final state 
-    return ChessBoard(
-        rawBoard, 
-        state.whiteKingCoord(),
-        state.blackKingCoord(),
-        newWhiteLeftCastling, 
-        newWhiteRightCastling, 
-        newBlackLeftCastling, 
-        newBlackRightCastling, 
-        newWhiteEnpassant, 
-        newBlackEnpassant
-    ); 
+    return ChessBoard(boardData); 
 }

--- a/chess_library_src/moves/queens_move.cpp
+++ b/chess_library_src/moves/queens_move.cpp
@@ -1,4 +1,5 @@
 #include "queens_move.h"
+#include "../utility.h"
 
 #include <stdexcept>
 
@@ -55,7 +56,8 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
     }
 
     // get raw board 
-    std::string rawBoard = state.board();
+    char boardData[34] = { 0 };
+    std::copy(state.boardData(), state.boardData() + 34, boardData);
 
     // get the move transformation and the destination square
     Vec2D singleMv = vecMap[_direction] * (_color == Color::WHITE ? 1 : -1), mv = singleMv * _numSteps;
@@ -74,16 +76,6 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
         }
     }
     
-    Coord2D newWhiteKingCoord = state.whiteKingCoord(), newBlackKingCoord = state.blackKingCoord();
-    
-    // keep track of enpassant/castling
-    bool newWhiteLeftCastling = state.whiteLeftCastling(), 
-    newWhiteRightCastling = state.whiteRightCastling(), 
-    newBlackLeftCastling  = state.blackLeftCastling(), 
-    newBlackRightCastling = state.blackRightCastling();
-    
-    std::optional<Coord2D> newWhiteEnpassant = std::nullopt, newBlackEnpassant = std::nullopt;
-    
     // only applies to pawn; end of row arrival -> queen promotion
     ChessPiece promote = state.getPiece(_origin);
     
@@ -98,8 +90,8 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
         if (_direction == Direction::UP_LEFT || _direction == Direction::UP_RIGHT) {
             if (_numSteps != 1) return std::nullopt;
             
-            bool isEnpassant = (_color == Color::WHITE && state.whiteEnpassant().has_value() && dest == state.whiteEnpassant().value()) || 
-                                (_color == Color::BLACK && state.blackEnpassant().has_value() && dest == state.blackEnpassant().value());
+            std::optional<Coord2D> enPassant = state.enpassant(_color);
+            bool isEnpassant = enPassant == dest;
 
             // diagonal move may only be performed to capture pieces/enpassant
             if (state.getPiece(dest).isNone() && !isEnpassant) return std::nullopt;
@@ -107,7 +99,7 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
             // enpassant requires the capture of the pawn in the corresponding square 
             if (isEnpassant) {
                 Coord2D capturedPawn = dest + ((_color == Color::WHITE) ? Vec2D(0, -1) : Vec2D(0, 1)); 
-                rawBoard[capturedPawn.toFlatIdx()] = ChessPiece::NONE;
+                internal::utility::writeData(boardData, capturedPawn, ChessPiece::NONE);
             }
         }
         
@@ -127,7 +119,7 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
                 if ((_color == Color::WHITE && _origin.row() != 2) || (_color == Color::BLACK && _origin.row() != 7)) return std::nullopt;
                 
                 // a 2-block jump will make the pawn liable to enpassant
-                _color == Color::WHITE ? newBlackEnpassant = occupiedCheck : newWhiteEnpassant = occupiedCheck;
+                internal::utility::setEnPassant(boardData, ~_color, occupiedCheck);
             }
             
             // pawn moving forward may not be possible if another piece is in front of it 
@@ -151,12 +143,16 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
         
         // rook's move may forfeit castling rights 
         if (_color == Color::WHITE) {
-            if (newWhiteLeftCastling && _origin == Coord2D('a', 1)) newWhiteLeftCastling = false;
-            else if (newWhiteRightCastling &&  _origin == Coord2D('h', 1)) newWhiteRightCastling = false;
+            if (state.castling(_color, true) && _origin == Coord2D('a', 1)) 
+                internal::utility::turnOffCastling(boardData, _color, true);
+            else if (state.castling(_color, false) &&  _origin == Coord2D('h', 1)) 
+                internal::utility::turnOffCastling(boardData, _color, false);;
         }
         else {
-            if (newBlackLeftCastling && _origin == Coord2D('h', 8)) newBlackLeftCastling = false;
-            else if (newBlackRightCastling && _origin == Coord2D('a', 8)) newBlackRightCastling = false;
+            if (state.castling(_color, true) && _origin == Coord2D('h', 8)) 
+                internal::utility::turnOffCastling(boardData, _color, true);
+            else if (state.castling(_color, false) && _origin == Coord2D('a', 8)) 
+                internal::utility::turnOffCastling(boardData, _color, false);
         }
     }
 
@@ -176,34 +172,18 @@ std::optional<ChessBoard> QueensMove::operator()(const ChessBoard& state) const 
         if (_numSteps > 1) return std::nullopt;
         
         // performing king's movement may forfeit castling rights
-        if (_color == Color::WHITE) {
-            newWhiteKingCoord = dest;
-            newWhiteLeftCastling = newWhiteRightCastling = false;
-        }
-        else {
-            newBlackKingCoord = dest;
-            newBlackLeftCastling = newBlackRightCastling = false;
-        }
+        internal::utility::turnOffCastling(boardData, _color, true);
+        internal::utility::turnOffCastling(boardData, _color, false);
     }
 
     // queen's move is by default
 
     // update castling rights of opponent
-    updateCastling(state, _color, dest, newWhiteLeftCastling, newWhiteRightCastling, newBlackLeftCastling, newBlackRightCastling);
+    updateCastling(state, _color, dest, boardData);
 
     // perform transformation 
-    rawBoard[_origin.toFlatIdx()] = ChessPiece::NONE;
-    rawBoard[dest.toFlatIdx()] = promote;
+    internal::utility::writeData(boardData, _origin, ChessPiece::NONE);
+    internal::utility::writeData(boardData, dest, promote);
 
-    return ChessBoard(
-        rawBoard, 
-        newWhiteKingCoord,
-        newBlackKingCoord,
-        newWhiteLeftCastling, 
-        newWhiteRightCastling, 
-        newBlackLeftCastling, 
-        newBlackRightCastling, 
-        newWhiteEnpassant, 
-        newBlackEnpassant
-    ); 
+    return ChessBoard(boardData); 
 }

--- a/chess_library_src/moves/underpromotion.cpp
+++ b/chess_library_src/moves/underpromotion.cpp
@@ -1,6 +1,8 @@
 #include "underpromotion.h"
+#include "../utility.h"
 
 #include <stdexcept>
+#include <cstring>
 
 /**
  * @brief Construct for the Underpromotion's move 
@@ -74,7 +76,8 @@ std::optional<ChessBoard> Underpromotion::operator()(const ChessBoard& state) co
     }
 
     // get raw board 
-    std::string rawBoard = state.board();
+    char boardData[34] = { 0 };
+    std::copy(state.boardData(), state.boardData() + 34, boardData);
 
     // get direction and new piece position after transformation
     Vec2D dir = vecMap[_direction];
@@ -100,31 +103,14 @@ std::optional<ChessBoard> Underpromotion::operator()(const ChessBoard& state) co
         return std::nullopt;
     }
 
-    // update en passant square (since a pawn is moving at the 2nd last row, there shall be no en passant square left)
-    constexpr std::optional<Coord2D> whiteEnpassant = std::nullopt;
-    constexpr std::optional<Coord2D> blackEnpassant = std::nullopt;
-
-    // update castling square 
-    bool newWhiteLeftCastling = state.whiteLeftCastling(), 
-        newWhiteRightCastling = state.whiteRightCastling(), 
-        newBlackLeftCastling  = state.blackLeftCastling(),
-        newBlackRightCastling = state.blackRightCastling();
-
-    updateCastling(state, _color, dest, newWhiteLeftCastling, newWhiteRightCastling, newBlackLeftCastling, newBlackRightCastling);
+    // update castling + en passant 
+    updateCastling(state, _color, dest, boardData);
+    internal::utility::turnOffEnpassant(boardData);
 
     uint8_t originIdx = _origin.toFlatIdx(), destIdx = dest.toFlatIdx();
     // perform transformation on raw board 
-    rawBoard[originIdx] = ChessPiece::NONE;
-    rawBoard[destIdx] = _promotePiece;
+    internal::utility::writeData(boardData, _origin, ChessPiece::NONE);
+    internal::utility::writeData(boardData, dest, _promotePiece);
 
-    return ChessBoard(
-        rawBoard, 
-        state.whiteKingCoord(),
-        state.blackKingCoord(),
-        newWhiteLeftCastling, 
-        newWhiteRightCastling, 
-        newBlackLeftCastling, 
-        newBlackRightCastling, 
-        whiteEnpassant, 
-        blackEnpassant);
+    return ChessBoard(boardData);
 }

--- a/chess_library_src/square_iterator/r_pawn.cpp
+++ b/chess_library_src/square_iterator/r_pawn.cpp
@@ -11,7 +11,7 @@ std::vector<Coord2D> RPawn::pieceCanReachSquare(const ChessBoard& state, Coord2D
 
     // determine the color of the piece 
     bool originPieceIsWhite = pieceAtOrigin.isWhite(); 
-    const std::optional<Coord2D>& enPassant = originPieceIsWhite ? state.whiteEnpassant() : state.blackEnpassant();
+    const std::optional<Coord2D>& enPassant = state.enpassant(pieceAtOrigin.color());
 
     // check if it can move forward 1/2 squares 
     Vec2D forward = originPieceIsWhite ? Vec2D(0, 1) : Vec2D(0, -1);

--- a/chess_library_src/utility.h
+++ b/chess_library_src/utility.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#include "chess_piece.h"
+#include "coord2D.h"
+
+#include <optional>
+#include <stdexcept>
+
+namespace internal {
+
+namespace utility { 
+
+inline void writeData(char* boardData, Coord2D coord, ChessPiece piece) {
+    
+    // get flat index, then locate the byte containing the coordinate
+    uint8_t flatIdx = coord.toFlatIdx(), byteLocn = flatIdx >> 1;
+
+    // create the bit mask
+    uint8_t mask = (1 << 4) - 1;
+    Piece_t rawPiece = piece;
+    if ((coord.col() - 'a') & 1) {
+        mask <<= 4;
+        rawPiece <<= 4;
+    }
+
+    // clear out original data 
+    boardData[byteLocn] &= ~mask;
+
+    // insert new data 
+    boardData[byteLocn] |= rawPiece;
+}
+
+[[nodiscard]] inline ChessPiece getData(const char* boardData, Coord2D coord) {
+    // get flat index, then locate the byte containing the coordinate
+    uint8_t flatIdx = coord.toFlatIdx(), byteLocn = flatIdx >> 1;
+    char byte = boardData[byteLocn];
+
+    // create bitmask
+    uint8_t mask = (1 << 4) - 1;
+
+    // if the columns are b/d/f/h -> bit shift appropriately
+    if ((coord.col() - 'a') & 1) {
+        byte >>= 4;
+    }
+
+
+    return ChessPiece(byte & mask);
+}
+
+[[nodiscard]] inline bool getCastling(const char* boardData, Color color, bool isQueenSide) {
+    
+    if (color == Color::NONE) {
+        throw std::invalid_argument("Getting castling rights of an undefined player");
+    }
+
+    // get the bit position corresponding to the color and the side 
+    int location = 2 * (color == Color::BLACK) + !isQueenSide;
+
+    // create the bitmask
+    char mask = 1 << location;
+
+    // get the result
+    return boardData[32] & mask;
+}
+
+inline void turnOffCastling(char* boardData, Color color, bool isQueenSide) {
+    
+    if (color == Color::NONE) {
+        throw std::invalid_argument("Setting castling rights of an undefined player");
+    }
+
+    // get the bit position corresponding to color and the side
+    int location = 2 * (color == Color::BLACK) + !isQueenSide;
+
+    // create bit mask 
+    char mask = ~(1 << location);
+
+    // flip the result
+    boardData[32] &= mask;
+}
+
+[[nodiscard]] inline std::optional<Coord2D> getEnPassant(const char* boardData, Color color) {
+
+    if (color == Color::NONE) {
+        throw std::invalid_argument("Getting en passant square of an undefined player");
+    }
+
+    // check if en passant is allowed in the first place
+    // en passant data is in byte 34
+    char enPassantData = boardData[33];
+
+    // 8th bit: whether any square is en passant square
+    // 7th bit: whether it's a white/black en passant
+    bool exist   = (enPassantData & (1 << 7)) >> 7;
+    bool isWhite = (enPassantData & (1 << 6)) >> 6;
+
+    if (!exist || isWhite != (color == Color::WHITE)) return std::nullopt;
+
+    // extract 1st-3rd bit for column, 4th-6th bit for row;
+    uint8_t mask = (1 << 3) - 1;
+    uint8_t colIdx =  enPassantData       & mask, col = colIdx + 'a';
+    uint8_t rowIdx = (enPassantData >> 3) & mask;
+    int8_t row  = rowIdx + 1;
+
+    // transform index to coordinates
+    return std::optional<Coord2D>(Coord2D(col, row));
+
+}
+
+inline void setEnPassant(char* boardData, Color color, Coord2D square) {
+    
+    if (color == Color::NONE) {
+        throw std::invalid_argument("Getting en passant square of an undefined player");
+    }
+
+    // en passant data is in byte 34
+    // enable en passant toggle 
+    boardData[33] |= 1 << 7;
+
+    // enable color (1: white, 0: black)
+    char playerMask = (color == Color::WHITE) ? 1 << 6 : 0;
+    boardData[33] |= playerMask;
+
+    // write coordinate into first 6 bits
+    char colEncoding = square.col() - 'a', colMask = colEncoding;
+    char rowEncoding = square.row() - 1,   rowMask = rowEncoding << 3;
+
+    // clear out the original data 
+    char clearMask = ~((1 << 6) - 1);
+    boardData[33] &= clearMask;
+
+    // insert new data
+    boardData[33] |= colMask;
+    boardData[33] |= rowMask;
+}
+
+inline void turnOffEnpassant(char* boardData) {
+    boardData[33] = 0;
+}
+
+}
+
+}

--- a/docs/chess_lib.drawio
+++ b/docs/chess_lib.drawio
@@ -1,13 +1,13 @@
 <mxfile host="65bd71144e">
     <diagram id="MbsbiXn9RqepsuUvK-sm" name="Page-1">
-        <mxGraphModel dx="1486" dy="530" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
+        <mxGraphModel dx="1380" dy="442" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="850" pageHeight="1100" math="0" shadow="0">
             <root>
                 <mxCell id="0"/>
                 <mxCell id="1" parent="0"/>
                 <mxCell id="10" value="moves" style="shape=umlFrame;whiteSpace=wrap;html=1;pointerEvents=0;" parent="1" vertex="1">
                     <mxGeometry x="30" y="900" width="1630" height="1210" as="geometry"/>
                 </mxCell>
-                <mxCell id="288" value="transforms" style="edgeStyle=orthogonalEdgeStyle;html=1;" edge="1" parent="1" source="12" target="258">
+                <mxCell id="288" value="transforms" style="edgeStyle=orthogonalEdgeStyle;html=1;" parent="1" source="12" target="258" edge="1">
                     <mxGeometry relative="1" as="geometry">
                         <Array as="points">
                             <mxPoint x="175" y="1044"/>
@@ -479,274 +479,232 @@
                 <mxCell id="192" value="0..*" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
                     <mxGeometry x="1050" y="1010" width="60" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="221" value="transforms" style="edgeStyle=none;html=1;" edge="1" parent="1" source="194" target="205">
+                <mxCell id="221" value="transforms" style="edgeStyle=none;html=1;" parent="1" source="194" target="205" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="194" value="Vec2D" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                <mxCell id="194" value="Vec2D" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="630" y="176" width="320" height="268" as="geometry"/>
                 </mxCell>
-                <mxCell id="195" value="- _mvRow: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="195" value="- _mvRow: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="26" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="198" value="- _mvCol: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="198" value="- _mvCol: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="52" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="196" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" vertex="1" parent="194">
+                <mxCell id="196" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" parent="194" vertex="1">
                     <mxGeometry y="78" width="320" height="8" as="geometry"/>
                 </mxCell>
-                <mxCell id="197" value="+ Vec2D(mvCol: int8_t, mvRow: int8_t)" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="197" value="+ Vec2D(mvCol: int8_t, mvRow: int8_t)" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="86" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="199" value="+ mvCol(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="199" value="+ mvCol(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="112" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="200" value="+ mvRow(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="200" value="+ mvRow(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="138" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="202" value="+ operator*=(num: int8_t): Vec2D&amp;amp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="202" value="+ operator*=(num: int8_t): Vec2D&amp;amp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="164" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="201" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator*(vec: Vec2D, num: int8_t): Vec2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="201" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator*(vec: Vec2D, num: int8_t): Vec2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="190" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="203" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator==(vec1: Vec2D, vec2: Vec2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="203" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator==(vec1: Vec2D, vec2: Vec2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="216" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="204" value="+ operator std::string()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="194">
+                <mxCell id="204" value="+ operator std::string()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="194" vertex="1">
                     <mxGeometry y="242" width="320" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="205" value="Coord2D" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                <mxCell id="205" value="Coord2D" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry y="137" width="360" height="346" as="geometry"/>
                 </mxCell>
-                <mxCell id="206" value="- _col: char" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="206" value="- _col: char" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="26" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="209" value="- _row: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="209" value="- _row: int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="52" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="210" value="+ BOARD_SIZE: const int8_t = 8" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;fontStyle=2" vertex="1" parent="205">
+                <mxCell id="210" value="+ BOARD_SIZE: const int8_t = 8" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;fontStyle=2" parent="205" vertex="1">
                     <mxGeometry y="78" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="207" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" vertex="1" parent="205">
+                <mxCell id="207" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" parent="205" vertex="1">
                     <mxGeometry y="104" width="360" height="8" as="geometry"/>
                 </mxCell>
-                <mxCell id="208" value="+ Coord2D(col: char, row: int8_t)" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="208" value="+ Coord2D(col: char, row: int8_t)" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="112" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="212" value="+ col(): char" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="212" value="+ col(): char" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="138" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="214" value="+ row(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="214" value="+ row(): int8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="164" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="215" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator==(first: Coord2D, second: Coord2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="215" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator==(first: Coord2D, second: Coord2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="190" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="216" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator!=(first: Coord2D, second: Coord2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="216" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator!=(first: Coord2D, second: Coord2D): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="216" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="217" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator+(coord: Coord2D, vec: Vec2D): Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="217" value="+ &amp;lt;&amp;lt;friend&amp;gt;&amp;gt; operator+(coord: Coord2D, vec: Vec2D): Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="242" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="218" value="+ operator+=(vec: Vec2D): Coord2D&amp;amp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="218" value="+ operator+=(vec: Vec2D): Coord2D&amp;amp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="268" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="219" value="+ toFlatIdx(): uint8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="219" value="+ toFlatIdx(): uint8_t" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="294" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="220" value="+ operator std::string()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="205">
+                <mxCell id="220" value="+ operator std::string()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="205" vertex="1">
                     <mxGeometry y="320" width="360" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="257" value="is of color" style="edgeStyle=none;html=1;endArrow=classic;endFill=1;startArrow=none;startFill=0;" edge="1" parent="1" source="222" target="251">
+                <mxCell id="257" value="is of color" style="edgeStyle=none;html=1;endArrow=classic;endFill=1;startArrow=none;startFill=0;" parent="1" source="222" target="251" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="222" value="&lt;i&gt;&amp;lt;&amp;lt;Enum&amp;gt;&amp;gt;&lt;/i&gt;&lt;div&gt;ChessPiece&lt;/div&gt;" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=40;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                <mxCell id="222" value="&lt;i&gt;&amp;lt;&amp;lt;Enum&amp;gt;&amp;gt;&lt;/i&gt;&lt;div&gt;ChessPiece&lt;/div&gt;" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=40;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="-560" y="137" width="210" height="698" as="geometry"/>
                 </mxCell>
-                <mxCell id="223" value="NONE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="223" value="NONE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="40" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="227" value="WHITE_PAWN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="227" value="WHITE_PAWN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="66" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="228" value="WHITE_ROOK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="228" value="WHITE_ROOK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="92" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="229" value="WHITE_KNIGHT" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="229" value="WHITE_KNIGHT" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="118" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="230" value="WHITE_BISHOP" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="230" value="WHITE_BISHOP" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="144" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="235" value="WHITE_QUEEN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="235" value="WHITE_QUEEN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="170" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="231" value="WHITE_KING" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="231" value="WHITE_KING" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="196" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="232" value="BLACK_PAWN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="232" value="BLACK_PAWN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="222" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="233" value="BLACK_ROOK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="233" value="BLACK_ROOK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="248" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="234" value="BLACK_KNIGHT" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="234" value="BLACK_KNIGHT" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="274" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="236" value="BLACK_BISHOP" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="236" value="BLACK_BISHOP" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="300" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="237" value="BLACK_QUEEN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="237" value="BLACK_QUEEN" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="326" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="238" value="BLACK_KING" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="238" value="BLACK_KING" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="352" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="224" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" vertex="1" parent="222">
+                <mxCell id="224" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" parent="222" vertex="1">
                     <mxGeometry y="378" width="210" height="8" as="geometry"/>
                 </mxCell>
-                <mxCell id="225" value="+ toAscii(): const char*" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="225" value="+ toAscii(): const char*" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="386" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="239" value="+ isNone(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="239" value="+ isNone(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="412" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="240" value="+ isWhite(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="240" value="+ isWhite(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="438" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="241" value="+ isBlack(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="241" value="+ isBlack(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="464" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="242" value="+ color(): Color" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="242" value="+ color(): Color" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="490" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="243" value="+ captures(piece: ChessPiece): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="243" value="+ captures(piece: ChessPiece): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="516" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="245" value="+ isPawn(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="245" value="+ isPawn(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="542" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="246" value="+ isRook(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="246" value="+ isRook(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="568" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="247" value="+ isKnight(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="247" value="+ isKnight(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="594" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="248" value="+ isBishop(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="248" value="+ isBishop(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="620" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="249" value="+ isQueen(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="249" value="+ isQueen(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="646" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="250" value="+ isKing(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="222">
+                <mxCell id="250" value="+ isKing(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="222" vertex="1">
                     <mxGeometry y="672" width="210" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="251" value="&lt;i&gt;&amp;lt;&amp;lt;Enum&amp;gt;&amp;gt;&lt;/i&gt;&lt;div&gt;Color&lt;/div&gt;" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=43;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+                <mxCell id="251" value="&lt;i&gt;&amp;lt;&amp;lt;Enum&amp;gt;&amp;gt;&lt;/i&gt;&lt;div&gt;Color&lt;/div&gt;" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=43;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
                     <mxGeometry x="-840" y="408.5" width="160" height="155" as="geometry"/>
                 </mxCell>
-                <mxCell id="252" value="NONE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="251">
+                <mxCell id="252" value="NONE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="251" vertex="1">
                     <mxGeometry y="43" width="160" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="255" value="WHITE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="251">
+                <mxCell id="255" value="WHITE" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="251" vertex="1">
                     <mxGeometry y="69" width="160" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="256" value="BLACK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="251">
+                <mxCell id="256" value="BLACK" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="251" vertex="1">
                     <mxGeometry y="95" width="160" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="253" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" vertex="1" parent="251">
+                <mxCell id="253" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" parent="251" vertex="1">
                     <mxGeometry y="121" width="160" height="8" as="geometry"/>
                 </mxCell>
-                <mxCell id="254" value="+ operator~(): Color" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="251">
+                <mxCell id="254" value="+ operator~(): Color" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="251" vertex="1">
                     <mxGeometry y="129" width="160" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="287" value="navigates using" style="edgeStyle=none;html=1;" edge="1" parent="1" source="258" target="205">
+                <mxCell id="287" value="navigates using" style="edgeStyle=none;html=1;" parent="1" source="258" target="205" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="289" value="contains" style="edgeStyle=none;html=1;" edge="1" parent="1" source="258" target="222">
+                <mxCell id="289" value="contains" style="edgeStyle=none;html=1;" parent="1" source="258" target="222" edge="1">
                     <mxGeometry relative="1" as="geometry"/>
                 </mxCell>
-                <mxCell id="258" value="ChessBoard" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
-                    <mxGeometry x="-590" y="1014" width="270" height="788" as="geometry"/>
+                <mxCell id="258" value="ChessBoard" style="swimlane;fontStyle=1;align=center;verticalAlign=top;childLayout=stackLayout;horizontal=1;startSize=26;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;whiteSpace=wrap;html=1;" parent="1" vertex="1">
+                    <mxGeometry x="-590" y="1014" width="280" height="292" as="geometry"/>
                 </mxCell>
-                <mxCell id="259" value="- _board: std::string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="26" width="270" height="26" as="geometry"/>
+                <mxCell id="259" value="- _boardData: char*" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="26" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="262" value="- _whiteKingCoord: Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="52" width="270" height="26" as="geometry"/>
+                <mxCell id="260" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" parent="258" vertex="1">
+                    <mxGeometry y="52" width="280" height="8" as="geometry"/>
                 </mxCell>
-                <mxCell id="263" value="- _blackKingCoord: Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="78" width="270" height="26" as="geometry"/>
+                <mxCell id="261" value="+ ChessBoard()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="60" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="264" value="- _whiteLeftCastling: bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="104" width="270" height="26" as="geometry"/>
+                <mxCell id="270" value="+ ChessBoard(boardData: const char*&lt;span style=&quot;background-color: transparent;&quot;&gt;)&lt;/span&gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="86" width="280" height="24" as="geometry"/>
                 </mxCell>
-                <mxCell id="265" value="- _whiteRightCastling: bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="130" width="270" height="26" as="geometry"/>
+                <mxCell id="271" value="+ boardData(): const char*" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="110" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="266" value="- _blackLeftCastling: bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="156" width="270" height="26" as="geometry"/>
+                <mxCell id="272" value="+ castling(color: Color, isQueenside: bool): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="136" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="267" value="- _blackRightCastling: bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="182" width="270" height="26" as="geometry"/>
+                <mxCell id="276" value="+ enpassant(color: Color): std::optional&amp;lt;Coord2D&amp;gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="162" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="268" value="- _whiteEnpassant: std::optional&amp;lt;Coord2D&amp;gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="208" width="270" height="26" as="geometry"/>
+                <mxCell id="280" value="+ getPiece(coord: Coord2D): ChessPiece&amp;nbsp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="188" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="269" value="- _blackEnpassant: std::optional&amp;lt;Coord2D&amp;gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="234" width="270" height="26" as="geometry"/>
+                <mxCell id="281" value="+ operator==(other: const ChessBoard&amp;amp;): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="214" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="260" value="" style="line;strokeWidth=1;fillColor=none;align=left;verticalAlign=middle;spacingTop=-1;spacingLeft=3;spacingRight=3;rotatable=0;labelPosition=right;points=[];portConstraint=eastwest;strokeColor=inherit;" vertex="1" parent="258">
-                    <mxGeometry y="260" width="270" height="8" as="geometry"/>
+                <mxCell id="282" value="+ getWhitePOV(): std::string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="240" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="261" value="+ ChessBoard()" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="268" width="270" height="26" as="geometry"/>
+                <mxCell id="283" value="+ getBlackPOV(): std::string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" parent="258" vertex="1">
+                    <mxGeometry y="266" width="280" height="26" as="geometry"/>
                 </mxCell>
-                <mxCell id="270" value="+ ChessBoard(&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;board: std::string,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;whiteKingCoord: Coord2D,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;blackKingCoord: Coord2D,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;whiteLeftCastling: bool,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;whiteRightCastling: bool,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;blackLeftCastling: bool,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;blackRightCastling: bool,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;whiteEnpassant: std::optional&amp;lt;Coord2D&amp;gt;,&amp;nbsp;&lt;/div&gt;&lt;div&gt;&lt;span style=&quot;white-space: pre;&quot;&gt;&#x9;&lt;/span&gt;blackEnpassant: std::optional&amp;lt;Coord2D&amp;gt;)&lt;/div&gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="294" width="270" height="156" as="geometry"/>
-                </mxCell>
-                <mxCell id="271" value="+ board(): const std::string&amp;amp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="450" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="272" value="+ whiteLeftCastling(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="476" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="273" value="+ whiteRightCastling(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="502" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="274" value="+ blackLeftCastling(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="528" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="275" value="+ blackRightCastling(): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="554" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="276" value="+ whiteEnpassant(): std::optional&amp;lt;Coord2D&amp;gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="580" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="277" value="+ blackEnpassant(): std::optional&amp;lt;Coord2D&amp;gt;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="606" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="278" value="+ whiteKingCoord(): Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="632" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="279" value="+ blackKingCoord(): Coord2D" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="658" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="280" value="+ getPiece(coord: Coord2D): ChessPiece&amp;nbsp;" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="684" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="281" value="+ operator==(other: const ChessBoard&amp;amp;): bool" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="710" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="282" value="+ getWhitePOV(): std::string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="736" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="283" value="+ getBlackPOB(): std::string" style="text;strokeColor=none;fillColor=none;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;whiteSpace=wrap;html=1;" vertex="1" parent="258">
-                    <mxGeometry y="762" width="270" height="26" as="geometry"/>
-                </mxCell>
-                <mxCell id="290" value="64" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                <mxCell id="290" value="64" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
                     <mxGeometry x="-455" y="835" width="60" height="30" as="geometry"/>
                 </mxCell>
-                <mxCell id="291" value="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" vertex="1" parent="1">
+                <mxCell id="291" value="1" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;" parent="1" vertex="1">
                     <mxGeometry x="-455" y="984" width="60" height="30" as="geometry"/>
                 </mxCell>
             </root>


### PR DESCRIPTION
Re-designed the ChessBoard class: 
- compressed from multiple members to a compact 34-byte array
- reduced number of methods by 4 

ChessPiece: 
- enum now starts from 0 to enhance compatibility with the new ChessBoard class 

New functions in utility.h:
- helps manipulate the byte array in a fast and safe manner